### PR TITLE
Use `--import` instead of `--experimental-loader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ export default {
 };
 ```
 
-Then run node with the `--experimental-loader` flag:
+Then run node with the `--import` flag:
 
 ```sh
-node --experimental-loader @node-loader/core file.js
+node --import="data:text/javascript,import {register} from 'node:module'; import {pathToFileURL} from 'node:url'; register('@node-loader/core', pathToFileURL('./'))" file.js
 ```
 
 Your code will now run with all loaders specified in the configuration file, merged into a single loader. When multiple loaders specify the same loader hook (such as `resolve`), they will be called sequentially until one of them returns a non-default value. The order in which they are called is the same order specified in the configuration file.
@@ -40,7 +40,7 @@ Your code will now run with all loaders specified in the configuration file, mer
 By default, node-loader core looks for a configuration file called `node-loader.config.js` in the current working directory. To specify the file path to the configuration file, provide the `NODE_LOADER_CONFIG` environment variable:
 
 ```sh
-NODE_LOADER_CONFIG=/Users/name/some/dir/node-loader.config.js node --experimental-loader @node-loader/core file.js
+NODE_LOADER_CONFIG=/Users/name/some/dir/node-loader.config.js node --import "data:text/javascript,import {register} from 'node:module'; import {pathToFileURL} from 'node:url'; register('@node-loader/core', pathToFileURL('./'))" file.js
 ```
 
 Within the file, only the `loaders` property is currently respected. In the future, additional configuration options may be defined.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Your code will now run with all loaders specified in the configuration file, mer
 By default, node-loader core looks for a configuration file called `node-loader.config.js` in the current working directory. To specify the file path to the configuration file, provide the `NODE_LOADER_CONFIG` environment variable:
 
 ```sh
-NODE_LOADER_CONFIG=/Users/name/some/dir/node-loader.config.js --experimental-loader @node-loader/core file.js
+NODE_LOADER_CONFIG=/Users/name/some/dir/node-loader.config.js node --experimental-loader @node-loader/core file.js
 ```
 
 Within the file, only the `loaders` property is currently respected. In the future, additional configuration options may be defined.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "lib/node-loader-core.js",
   "scripts": {
-    "test": "node --experimental-loader ./lib/node-loader-core.js ./test/run-tests.js",
+    "test": "node --import=\"data:text/javascript,import {register} from 'node:module'; import {pathToFileURL} from 'node:url'; register('./lib/node-loader-core.js', pathToFileURL('./'))\" ./test/run-tests.js",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "lint": "eslint lib test"


### PR DESCRIPTION
Maybe a better idea would be to modify the exported module so that `--import @node-loader/core` just works? Then I guess we could apply the same fix to individual loaders: `@node-loader/babel`, `@node-loader/import-maps`, etc.